### PR TITLE
Verify sequences instead of collections

### DIFF
--- a/Dobby/Mock.swift
+++ b/Dobby/Mock.swift
@@ -14,16 +14,15 @@ public func record<Interaction: Equatable>(mock: Mock<Interaction>, interaction:
 
 // MARK: - Verification
 
-public func verify<Interaction: Equatable, C: CollectionType where C.Generator.Element == Interaction>(mock: Mock<Interaction>, interactions: C) -> Bool {
-    var index = interactions.startIndex
+public func verify<Interaction: Equatable, S: SequenceType where S.Generator.Element == Interaction>(mock: Mock<Interaction>, interactions: S) -> Bool {
+    var generator = interactions.generate()
+    var element = generator.next()
+
     for interaction in mock.interactions {
-        if interaction == interactions[index] {
-            index = advance(index, 1)
-            if index == interactions.endIndex {
-                return true
-            }
+        if interaction == element {
+            element = generator.next()
         }
     }
 
-    return false
+    return element == nil
 }

--- a/DobbyTests/MockSpec.swift
+++ b/DobbyTests/MockSpec.swift
@@ -22,6 +22,7 @@ class MockSpec: QuickSpec {
 
         describe("Verifying interactions") {
             it("should check in-order") {
+                expect(verify(mock, [])).to(beTrue())
                 expect(verify(mock, [ 1, 3 ])).to(beTrue())
                 expect(verify(mock, [ 3, 1 ])).to(beFalse())
             }


### PR DESCRIPTION
Switch verification from `CollectionType` to `SequenceType`.
