### PR TITLE
Fail fast

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
 github "Quick/Quick" ~> 0.3
-github "Quick/Nimble" ~> 0.4
+github "Quick/Nimble" ~> 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v0.4.2"
+github "Quick/Nimble" "v1.0.0"
 github "Quick/Quick" "v0.3.1"

--- a/Dobby/Mock.swift
+++ b/Dobby/Mock.swift
@@ -17,7 +17,24 @@ public final class Mock<Interaction> {
     }
 
     /// Records the given interaction.
-    public func record(interaction: Interaction) {
+    public func record(interaction: Interaction, file: String = __FILE__, line: UInt = __LINE__) {
+        record(interaction, file: file, line: line, fail: XCTFail)
+    }
+
+    public func record(interaction: Interaction, file: String = __FILE__, line: UInt = __LINE__, fail: (String, file: String, line: UInt) -> ()) {
+        var unexpectedInteraction = true
+        for expectation in expectations {
+            if expectation.matches(interaction) {
+                unexpectedInteraction = false
+                break
+            }
+        }
+
+        if unexpectedInteraction {
+            fail("Received unexpected Interaction <\(interaction)>", file: file, line: line)
+            return
+        }
+
         interactions.append(interaction)
     }
 

--- a/DobbyTests/MockSpec.swift
+++ b/DobbyTests/MockSpec.swift
@@ -15,8 +15,8 @@ class MockSpec: QuickSpec {
             it("succeeds if all expectations match an interaction") {
                 mock.expect(matches((any(), 1)))
                 mock.expect(matches((any(), matches { $0 == 2 })))
-                mock.record(0, 1)
-                mock.record(0, 2)
+                mock.record((0, 1))
+                mock.record((0, 2))
                 mock.verify()
             }
 
@@ -28,21 +28,14 @@ class MockSpec: QuickSpec {
             }
 
             it("fails if an interaction is not matched") {
-                mock.record(4, 5)
-                mock.verify { (message, _, _) in
-                    expect(message).to(equal("Interaction <(4, 5)> not matched"))
+                var failureMessageSent = false
+                mock.record((4, 5)) { (message, _, _) in
+                    failureMessageSent = true
+                    expect(message).to(equal("Received unexpected Interaction <(4, 5)>"))
                 }
+                expect(failureMessageSent).to(beTrue())
             }
 
-            it("fails if any expectation does not match an interaction") {
-                mock.expect(matches((6, 7)))
-                mock.expect(matches((8, matches { $0 == 9 })))
-                mock.record(6, 7)
-                mock.record(8, 10)
-                mock.verify { (message, _, _) in
-                    expect(message).to(equal("Expectation <(8, <func>)> does not match interaction <(8, 10)>"))
-                }
-            }
         }
     }
 }

--- a/DobbyTests/MockSpec.swift
+++ b/DobbyTests/MockSpec.swift
@@ -21,10 +21,13 @@ class MockSpec: QuickSpec {
             }
 
             it("fails if an expectation is not matched") {
+                var failureMessageSent = false
                 mock.expect(matches((any(), equals(3))))
                 mock.verify { (message, _, _) in
+                    failureMessageSent = true
                     expect(message).to(equal("Expectation <(_, 3)> not matched"))
                 }
+                expect(failureMessageSent).to(beTrue())
             }
 
             it("fails if an interaction is not matched") {


### PR DESCRIPTION
This pull requests makes a `Mock` fail immediately when receiving an unexpected `Interaction`.

I've also updated Nimble to `1.0.0`.

Closes #18 
