### PR TITLE
Optionals

### DIFF
--- a/Dobby/Expectation.swift
+++ b/Dobby/Expectation.swift
@@ -39,9 +39,10 @@ public func none<Value>() -> Expectation<Value?> {
 /// Returns a new expectation that matches something (in the sense of whatever
 /// the given expectation matches).
 public func some<E: ExpectationConvertible>(expectation: E) -> Expectation<E.ValueType?> {
-    return Expectation(description: expectation.expectation().description) { actualValue in
+    let actualExpectation = expectation.expectation()
+    return Expectation(description: actualExpectation.description) { actualValue in
         if let actualValue = actualValue {
-            return expectation.expectation().matches(actualValue)
+            return actualExpectation.matches(actualValue)
         }
 
         return false

--- a/Dobby/Expectation.swift
+++ b/Dobby/Expectation.swift
@@ -29,6 +29,25 @@ public func any<Value>() -> Expectation<Value> {
     return Expectation(description: "_") { _ in true }
 }
 
+/// Returns a new expectation that matches nothing (in the sense of nil).
+public func none<Value>() -> Expectation<Value?> {
+    return Expectation(description: "nil") { actualValue in
+        return (actualValue ?? nil) == nil
+    }
+}
+
+/// Returns a new expectation that matches something (in the sense of whatever
+/// the given expectation matches).
+public func some<E: ExpectationConvertible>(expectation: E) -> Expectation<E.ValueType?> {
+    return Expectation(description: expectation.expectation().description) { actualValue in
+        if let actualValue = actualValue {
+            return expectation.expectation().matches(actualValue)
+        }
+
+        return false
+    }
+}
+
 /// Returns a new expectation that matches the given value.
 public func equals<Value: Equatable>(value: Value) -> Expectation<Value> {
     return Expectation(description: "\(value)") { actualValue in

--- a/Dobby/Expectation.swift
+++ b/Dobby/Expectation.swift
@@ -25,17 +25,15 @@ public func matches<Value>(matches: Value -> Bool) -> Expectation<Value> {
 }
 
 /// Returns a new expectation that matches anything.
-///
-/// - SeeAlso: `Expectation.init<Value>()`
 public func any<Value>() -> Expectation<Value> {
-    return Expectation(description: "_", matches: { _ in true })
+    return Expectation(description: "_") { _ in true }
 }
 
 /// Returns a new expectation that matches the given value.
-///
-/// - SeeAlso: `Expectation.init<Value>(value: Value)`
 public func equals<Value: Equatable>(value: Value) -> Expectation<Value> {
-    return Expectation(description: "\(value)", matches: { actualValue in value == actualValue })
+    return Expectation(description: "\(value)") { actualValue in
+        return value == actualValue
+    }
 }
 
 /// Returns a new expectation that matches the given 2-tuple.
@@ -80,12 +78,16 @@ public func equals<A: Equatable, B: Equatable, C: Equatable, D: Equatable, E: Eq
 
 /// Returns a new expectation that matches the given array.
 public func equals<Element: Equatable>(value: [Element]) -> Expectation<[Element]> {
-    return Expectation(description: "\(value)") { actualValue in value == actualValue }
+    return Expectation(description: "\(value)") { actualValue in
+        return value == actualValue
+    }
 }
 
 /// Returns a new expectation that matches the given dictionary.
 public func equals<Key: Equatable, Value: Equatable>(value: [Key: Value]) -> Expectation<[Key: Value]> {
-    return Expectation(description: "\(value)") { actualValue in value == actualValue }
+    return Expectation(description: "\(value)") { actualValue in
+        return value == actualValue
+    }
 }
 
 /// Conforming types can be converted to an expectation.

--- a/Dobby/Extensions/SwiftExtensions.swift
+++ b/Dobby/Extensions/SwiftExtensions.swift
@@ -1,29 +1,29 @@
 extension Bool: ExpectationConvertible {
     public func expectation() -> Expectation<Bool> {
-        return Expectation(description: "\(self)", matches: { actualValue in self == actualValue })
+        return equals(self)
     }
 }
 
 extension Int: ExpectationConvertible {
     public func expectation() -> Expectation<Int> {
-        return Expectation(description: "\(self)", matches: { actualValue in self == actualValue })
+        return equals(self)
     }
 }
 
 extension Float: ExpectationConvertible {
     public func expectation() -> Expectation<Float> {
-        return Expectation(description: "\(self)", matches: { actualValue in self == actualValue })
+        return equals(self)
     }
 }
 
 extension Double: ExpectationConvertible {
     public func expectation() -> Expectation<Double> {
-        return Expectation(description: "\(self)", matches: { actualValue in self == actualValue })
+        return equals(self)
     }
 }
 
 extension String: ExpectationConvertible {
     public func expectation() -> Expectation<String> {
-        return Expectation(description: "\(self)", matches: { actualValue in self == actualValue })
+        return equals(self)
     }
 }

--- a/DobbyTests/ExpectationSpec.swift
+++ b/DobbyTests/ExpectationSpec.swift
@@ -27,6 +27,31 @@ class ExpectationSpec: QuickSpec {
                 }
             }
 
+            context("nothing") {
+                let expectation: Dobby.Expectation<Int?> = none()
+
+                it("succeeds if the actual value equals nil") {
+                    expect(expectation.matches(nil)).to(beTrue())
+                }
+
+                it("fails if the actual value does not equal nil") {
+                    expect(expectation.matches(0)).to(beFalse())
+                }
+            }
+
+            context("something") {
+                let expectation: Dobby.Expectation<Int?> = some(0)
+
+                it("succeeds if the given expectation is matched") {
+                    expect(expectation.matches(0)).to(beTrue())
+                }
+
+                it("fails if the given expectation is not matched") {
+                    expect(expectation.matches(nil)).to(beFalse())
+                    expect(expectation.matches(1)).to(beFalse())
+                }
+            }
+
             context("a value") {
                 let expectation: Dobby.Expectation<Int> = equals(0)
 


### PR DESCRIPTION
[Nimble](https://github.com/Quick/Nimble) accepts optionals to both actual and expected values, thereby always allowing to pass in `nil` or `beNil()`. We could do something similar, but would hit certain limitations when it comes to tuples, which are very important in our case.

To avoid confusion, I suggest we start with two helper functions, `none()` and `some(expectation:)`. The former simply matches `nil`, the latter lifts any given expectation—`ExpectationConvertible`—into one that matches the same value type but wrapped in an optional. This is very clear and easy to understand.

Closes #15.
