### PR TITLE
Verify with delay

### DIFF
--- a/Dobby/Mock.swift
+++ b/Dobby/Mock.swift
@@ -52,4 +52,22 @@ public final class Mock<Interaction> {
             fail("Expectation <\(expectation)> not matched", file: file, line: line)
         }
     }
+
+    /// Verifies that all set up expectations are matched within the given
+    /// delay.
+    public func verifyWithDelay(_ delay: NSTimeInterval = 1.0, file: String = __FILE__, line: UInt = __LINE__) {
+        verifyWithDelay(delay, file: file, line: line, fail: XCTFail)
+    }
+
+    /// INTERNAL API
+    public func verifyWithDelay(var delay: NSTimeInterval, file: String = __FILE__, line: UInt = __LINE__, fail: (String, file: String, line: UInt) -> ()) {
+        var step = 0.01
+
+        while delay > 0 && expectations.count > 0 {
+            NSRunLoop.currentRunLoop().runUntilDate(NSDate(timeIntervalSinceNow: step))
+            delay -= step; step *= 2
+        }
+
+        verify(file: file, line: line, fail: fail)
+    }
 }

--- a/DobbyTests/MockSpec.swift
+++ b/DobbyTests/MockSpec.swift
@@ -115,6 +115,35 @@ class MockSpec: QuickSpec {
                 }
 
                 expect(failureMessage).to(equal("Expectation <(_, 3)> not matched"))
+
+        describe("Verification with delay") {
+            beforeEach {
+                mock = Mock()
+            }
+
+            it("succeeds if all expectations are matched within the given delay") {
+                mock.expect(matches((any(), 1)))
+                mock.expect(matches((any(), matches { $0 == 2 })))
+                mock.record((0, 1))
+
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(0.25 * Double(NSEC_PER_SEC))), dispatch_get_main_queue()) {
+                    mock.record((0, 2))
+                }
+
+                mock.verifyWithDelay(0.5)
+            }
+
+            it("fails if any expectation is matched within the given delay") {
+                var failureMessage: String?
+
+                mock.expect(matches((any(), 1)))
+                mock.expect(matches((any(), equals(2))))
+                mock.record((0, 1))
+                mock.verifyWithDelay(0.25) { (message, _, _) in
+                    failureMessage = message
+                }
+
+                expect(failureMessage).to(equal("Expectation <(_, 2)> not matched"))
             }
         }
     }

--- a/DobbyTests/MockSpec.swift
+++ b/DobbyTests/MockSpec.swift
@@ -98,7 +98,7 @@ class MockSpec: QuickSpec {
                 mock = Mock()
             }
 
-            it("succeeds if all interactions match an expectation") {
+            it("succeeds if all expectations are matched") {
                 mock.expect(matches((any(), 1)))
                 mock.expect(matches((any(), matches { $0 == 2 })))
                 mock.record((0, 1))
@@ -106,15 +106,19 @@ class MockSpec: QuickSpec {
                 mock.verify()
             }
 
-            it("fails if an expectation is not matched") {
+            it("fails if any expectation is not matched") {
                 var failureMessage: String?
 
-                mock.expect(matches((any(), equals(3))))
+                mock.expect(matches((any(), 1)))
+                mock.expect(matches((any(), equals(2))))
+                mock.record((0, 1))
                 mock.verify { (message, _, _) in
                     failureMessage = message
                 }
 
-                expect(failureMessage).to(equal("Expectation <(_, 3)> not matched"))
+                expect(failureMessage).to(equal("Expectation <(_, 2)> not matched"))
+            }
+        }
 
         describe("Verification with delay") {
             beforeEach {


### PR DESCRIPTION
Adds verification with delay (default: `1.0` seconds). Steps double as on [OCMock's `verifyWithDelay`](https://github.com/erikdoe/ocmock/blob/master/Source/OCMock/OCMockObject.m#L196).

Closes #14.
