### PR TITLE
Fix nice, ordered mocks hanging on negative expectations

### DIFF
--- a/Dobby/Mock.swift
+++ b/Dobby/Mock.swift
@@ -79,7 +79,9 @@ public final class Mock<Interaction> {
                     fail("Interaction <\(interaction)> does not match expectation <\(expectation)>", file, line)
                 }
 
-                return
+                if expectation.negative == false {
+                    return
+                }
             }
         }
 

--- a/DobbyTests/MockSpec.swift
+++ b/DobbyTests/MockSpec.swift
@@ -159,6 +159,15 @@ class MockSpec: QuickSpec {
 
                     expect(failureMessage).to(equal("Expectation <(_, 2)> not fulfilled"))
                 }
+
+                context("when an expectation is negative and it does not match") {
+                    it("continues matching against the remaining expectations") {
+                        mock.reject(matches((1, 2)))
+                        mock.expect(matches((3, 4)))
+                        mock.record((3, 4))
+                        mock.verify()
+                    }
+                }
             }
 
             context("when the mock is nice and the order of expectations does not matter") {


### PR DESCRIPTION
If the current expectation is negative, not matched by the interaction, and the mock is ordered (and nice), attempt to fulfill the next expectation.

Fixes #38.