### PR TITLE
Preview: Introducing patterns

### DIFF
--- a/Dobby.xcodeproj/project.pbxproj
+++ b/Dobby.xcodeproj/project.pbxproj
@@ -16,6 +16,10 @@
 		DC4D88391E1CECE100FAE93F /* Recorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D88371E1CECE100FAE93F /* Recorder.swift */; };
 		DC4D883B1E1CF8D700FAE93F /* RecorderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D883A1E1CF8D700FAE93F /* RecorderSpec.swift */; };
 		DC4D883C1E1CF8D700FAE93F /* RecorderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D883A1E1CF8D700FAE93F /* RecorderSpec.swift */; };
+		DC4D883E1E1CFCAE00FAE93F /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D883D1E1CFCAE00FAE93F /* Behavior.swift */; };
+		DC4D883F1E1CFCAE00FAE93F /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D883D1E1CFCAE00FAE93F /* Behavior.swift */; };
+		DC4D88441E1F9A5500FAE93F /* BehaviorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D88431E1F9A5500FAE93F /* BehaviorSpec.swift */; };
+		DC4D88451E1F9A5500FAE93F /* BehaviorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D88431E1F9A5500FAE93F /* BehaviorSpec.swift */; };
 		DC7F6AFE1AD8291800CCBF6D /* Dobby.h in Headers */ = {isa = PBXBuildFile; fileRef = DC7F6AFD1AD8291800CCBF6D /* Dobby.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DC7F6B041AD8291800CCBF6D /* Dobby.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC7F6AF81AD8291800CCBF6D /* Dobby.framework */; };
 		DC7F6B1E1AD82B8C00CCBF6D /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7F6B1D1AD82B8C00CCBF6D /* Stub.swift */; };
@@ -78,6 +82,8 @@
 		DC457AD81B5552CA00919032 /* Matcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Matcher.swift; sourceTree = "<group>"; };
 		DC4D88371E1CECE100FAE93F /* Recorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Recorder.swift; sourceTree = "<group>"; };
 		DC4D883A1E1CF8D700FAE93F /* RecorderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecorderSpec.swift; sourceTree = "<group>"; };
+		DC4D883D1E1CFCAE00FAE93F /* Behavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Behavior.swift; sourceTree = "<group>"; };
+		DC4D88431E1F9A5500FAE93F /* BehaviorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BehaviorSpec.swift; sourceTree = "<group>"; };
 		DC7F6AF81AD8291800CCBF6D /* Dobby.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Dobby.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC7F6AFC1AD8291800CCBF6D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DC7F6AFD1AD8291800CCBF6D /* Dobby.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Dobby.h; sourceTree = "<group>"; };
@@ -190,6 +196,7 @@
 		DC7F6AFA1AD8291800CCBF6D /* Dobby */ = {
 			isa = PBXGroup;
 			children = (
+				DC4D883D1E1CFCAE00FAE93F /* Behavior.swift */,
 				DC83356B1B56661900569709 /* Disposable.swift */,
 				DC7F6AFD1AD8291800CCBF6D /* Dobby.h */,
 				DC457AD81B5552CA00919032 /* Matcher.swift */,
@@ -213,6 +220,7 @@
 		DC7F6B071AD8291800CCBF6D /* DobbyTests */ = {
 			isa = PBXGroup;
 			children = (
+				DC4D88431E1F9A5500FAE93F /* BehaviorSpec.swift */,
 				DCE4080D1B6161000009E0B4 /* MatcherSpec.swift */,
 				DC7F6B241AD830A500CCBF6D /* MockSpec.swift */,
 				DC4D883A1E1CF8D700FAE93F /* RecorderSpec.swift */,
@@ -506,6 +514,7 @@
 				DC7F6B1E1AD82B8C00CCBF6D /* Stub.swift in Sources */,
 				DC7F6B201AD82D3800CCBF6D /* Mock.swift in Sources */,
 				DC4D88391E1CECE100FAE93F /* Recorder.swift in Sources */,
+				DC4D883F1E1CFCAE00FAE93F /* Behavior.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -516,6 +525,7 @@
 				DCE4080E1B6161000009E0B4 /* MatcherSpec.swift in Sources */,
 				DC7F6B251AD830A500CCBF6D /* MockSpec.swift in Sources */,
 				DC4D883C1E1CF8D700FAE93F /* RecorderSpec.swift in Sources */,
+				DC4D88451E1F9A5500FAE93F /* BehaviorSpec.swift in Sources */,
 				DC7F6B271AD830B500CCBF6D /* StubSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -530,6 +540,7 @@
 				DC8452401ADBF73C006AC5D4 /* Stub.swift in Sources */,
 				DC84523F1ADBF73C006AC5D4 /* Mock.swift in Sources */,
 				DC4D88381E1CECE100FAE93F /* Recorder.swift in Sources */,
+				DC4D883E1E1CFCAE00FAE93F /* Behavior.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -540,6 +551,7 @@
 				DCE4080F1B6161000009E0B4 /* MatcherSpec.swift in Sources */,
 				DC8452421ADBF743006AC5D4 /* MockSpec.swift in Sources */,
 				DC4D883B1E1CF8D700FAE93F /* RecorderSpec.swift in Sources */,
+				DC4D88441E1F9A5500FAE93F /* BehaviorSpec.swift in Sources */,
 				DC8452431ADBF743006AC5D4 /* StubSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Dobby.xcodeproj/project.pbxproj
+++ b/Dobby.xcodeproj/project.pbxproj
@@ -12,6 +12,10 @@
 		DC3CFE791ADE895E004728C2 /* SwiftExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3CFE771ADE895E004728C2 /* SwiftExtensions.swift */; };
 		DC457AD91B5552CA00919032 /* Matcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC457AD81B5552CA00919032 /* Matcher.swift */; };
 		DC457ADA1B5552CA00919032 /* Matcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC457AD81B5552CA00919032 /* Matcher.swift */; };
+		DC4D88381E1CECE100FAE93F /* Recorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D88371E1CECE100FAE93F /* Recorder.swift */; };
+		DC4D88391E1CECE100FAE93F /* Recorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D88371E1CECE100FAE93F /* Recorder.swift */; };
+		DC4D883B1E1CF8D700FAE93F /* RecorderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D883A1E1CF8D700FAE93F /* RecorderSpec.swift */; };
+		DC4D883C1E1CF8D700FAE93F /* RecorderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D883A1E1CF8D700FAE93F /* RecorderSpec.swift */; };
 		DC7F6AFE1AD8291800CCBF6D /* Dobby.h in Headers */ = {isa = PBXBuildFile; fileRef = DC7F6AFD1AD8291800CCBF6D /* Dobby.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DC7F6B041AD8291800CCBF6D /* Dobby.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC7F6AF81AD8291800CCBF6D /* Dobby.framework */; };
 		DC7F6B1E1AD82B8C00CCBF6D /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7F6B1D1AD82B8C00CCBF6D /* Stub.swift */; };
@@ -72,6 +76,8 @@
 /* Begin PBXFileReference section */
 		DC3CFE771ADE895E004728C2 /* SwiftExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExtensions.swift; sourceTree = "<group>"; };
 		DC457AD81B5552CA00919032 /* Matcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Matcher.swift; sourceTree = "<group>"; };
+		DC4D88371E1CECE100FAE93F /* Recorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Recorder.swift; sourceTree = "<group>"; };
+		DC4D883A1E1CF8D700FAE93F /* RecorderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecorderSpec.swift; sourceTree = "<group>"; };
 		DC7F6AF81AD8291800CCBF6D /* Dobby.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Dobby.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC7F6AFC1AD8291800CCBF6D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DC7F6AFD1AD8291800CCBF6D /* Dobby.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Dobby.h; sourceTree = "<group>"; };
@@ -188,6 +194,7 @@
 				DC7F6AFD1AD8291800CCBF6D /* Dobby.h */,
 				DC457AD81B5552CA00919032 /* Matcher.swift */,
 				DC7F6B1F1AD82D3800CCBF6D /* Mock.swift */,
+				DC4D88371E1CECE100FAE93F /* Recorder.swift */,
 				DC7F6B1D1AD82B8C00CCBF6D /* Stub.swift */,
 				DC3CFE761ADE895E004728C2 /* Extensions */,
 				DC7F6AFB1AD8291800CCBF6D /* Supporting Files */,
@@ -208,6 +215,7 @@
 			children = (
 				DCE4080D1B6161000009E0B4 /* MatcherSpec.swift */,
 				DC7F6B241AD830A500CCBF6D /* MockSpec.swift */,
+				DC4D883A1E1CF8D700FAE93F /* RecorderSpec.swift */,
 				DC7F6B261AD830B500CCBF6D /* StubSpec.swift */,
 				DC7F6B081AD8291800CCBF6D /* Supporting Files */,
 			);
@@ -497,6 +505,7 @@
 				DC83356C1B56661900569709 /* Disposable.swift in Sources */,
 				DC7F6B1E1AD82B8C00CCBF6D /* Stub.swift in Sources */,
 				DC7F6B201AD82D3800CCBF6D /* Mock.swift in Sources */,
+				DC4D88391E1CECE100FAE93F /* Recorder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -506,6 +515,7 @@
 			files = (
 				DCE4080E1B6161000009E0B4 /* MatcherSpec.swift in Sources */,
 				DC7F6B251AD830A500CCBF6D /* MockSpec.swift in Sources */,
+				DC4D883C1E1CF8D700FAE93F /* RecorderSpec.swift in Sources */,
 				DC7F6B271AD830B500CCBF6D /* StubSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -519,6 +529,7 @@
 				DC83356D1B56661900569709 /* Disposable.swift in Sources */,
 				DC8452401ADBF73C006AC5D4 /* Stub.swift in Sources */,
 				DC84523F1ADBF73C006AC5D4 /* Mock.swift in Sources */,
+				DC4D88381E1CECE100FAE93F /* Recorder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -528,6 +539,7 @@
 			files = (
 				DCE4080F1B6161000009E0B4 /* MatcherSpec.swift in Sources */,
 				DC8452421ADBF743006AC5D4 /* MockSpec.swift in Sources */,
+				DC4D883B1E1CF8D700FAE93F /* RecorderSpec.swift in Sources */,
 				DC8452431ADBF743006AC5D4 /* StubSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Dobby.xcodeproj/project.pbxproj
+++ b/Dobby.xcodeproj/project.pbxproj
@@ -22,18 +22,18 @@
 		DC4D88451E1F9A5500FAE93F /* PatternSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D88431E1F9A5500FAE93F /* PatternSpec.swift */; };
 		DC7F6AFE1AD8291800CCBF6D /* Dobby.h in Headers */ = {isa = PBXBuildFile; fileRef = DC7F6AFD1AD8291800CCBF6D /* Dobby.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DC7F6B041AD8291800CCBF6D /* Dobby.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC7F6AF81AD8291800CCBF6D /* Dobby.framework */; };
-		DC7F6B1E1AD82B8C00CCBF6D /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7F6B1D1AD82B8C00CCBF6D /* Stub.swift */; };
+		DC7F6B1E1AD82B8C00CCBF6D /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7F6B1D1AD82B8C00CCBF6D /* Behavior.swift */; };
 		DC7F6B201AD82D3800CCBF6D /* Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7F6B1F1AD82D3800CCBF6D /* Mock.swift */; };
 		DC7F6B251AD830A500CCBF6D /* MockSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7F6B241AD830A500CCBF6D /* MockSpec.swift */; };
-		DC7F6B271AD830B500CCBF6D /* StubSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7F6B261AD830B500CCBF6D /* StubSpec.swift */; };
+		DC7F6B271AD830B500CCBF6D /* BehaviorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7F6B261AD830B500CCBF6D /* BehaviorSpec.swift */; };
 		DC83356C1B56661900569709 /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC83356B1B56661900569709 /* Disposable.swift */; };
 		DC83356D1B56661900569709 /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC83356B1B56661900569709 /* Disposable.swift */; };
 		DC8452231ADBF5CC006AC5D4 /* Dobby.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC8452181ADBF5CC006AC5D4 /* Dobby.framework */; };
 		DC84523E1ADBF73C006AC5D4 /* Dobby.h in Headers */ = {isa = PBXBuildFile; fileRef = DC7F6AFD1AD8291800CCBF6D /* Dobby.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DC84523F1ADBF73C006AC5D4 /* Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7F6B1F1AD82D3800CCBF6D /* Mock.swift */; };
-		DC8452401ADBF73C006AC5D4 /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7F6B1D1AD82B8C00CCBF6D /* Stub.swift */; };
+		DC8452401ADBF73C006AC5D4 /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7F6B1D1AD82B8C00CCBF6D /* Behavior.swift */; };
 		DC8452421ADBF743006AC5D4 /* MockSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7F6B241AD830A500CCBF6D /* MockSpec.swift */; };
-		DC8452431ADBF743006AC5D4 /* StubSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7F6B261AD830B500CCBF6D /* StubSpec.swift */; };
+		DC8452431ADBF743006AC5D4 /* BehaviorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7F6B261AD830B500CCBF6D /* BehaviorSpec.swift */; };
 		DCDDA9301BED650100BB5228 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCDDA92F1BED650100BB5228 /* Nimble.framework */; };
 		DCDDA9321BED655500BB5228 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCDDA9311BED655500BB5228 /* Quick.framework */; };
 		DCDDA9351BED657C00BB5228 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCDDA92F1BED650100BB5228 /* Nimble.framework */; };
@@ -89,10 +89,10 @@
 		DC7F6AFD1AD8291800CCBF6D /* Dobby.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Dobby.h; sourceTree = "<group>"; };
 		DC7F6B031AD8291800CCBF6D /* DobbyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DobbyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC7F6B091AD8291800CCBF6D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		DC7F6B1D1AD82B8C00CCBF6D /* Stub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stub.swift; sourceTree = "<group>"; };
+		DC7F6B1D1AD82B8C00CCBF6D /* Behavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Behavior.swift; sourceTree = "<group>"; };
 		DC7F6B1F1AD82D3800CCBF6D /* Mock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mock.swift; sourceTree = "<group>"; };
 		DC7F6B241AD830A500CCBF6D /* MockSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockSpec.swift; sourceTree = "<group>"; };
-		DC7F6B261AD830B500CCBF6D /* StubSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StubSpec.swift; sourceTree = "<group>"; };
+		DC7F6B261AD830B500CCBF6D /* BehaviorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BehaviorSpec.swift; sourceTree = "<group>"; };
 		DC83356B1B56661900569709 /* Disposable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Disposable.swift; sourceTree = "<group>"; };
 		DC8452181ADBF5CC006AC5D4 /* Dobby.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Dobby.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC8452221ADBF5CC006AC5D4 /* DobbyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DobbyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -196,13 +196,13 @@
 		DC7F6AFA1AD8291800CCBF6D /* Dobby */ = {
 			isa = PBXGroup;
 			children = (
+				DC7F6B1D1AD82B8C00CCBF6D /* Behavior.swift */,
 				DC83356B1B56661900569709 /* Disposable.swift */,
 				DC7F6AFD1AD8291800CCBF6D /* Dobby.h */,
 				DC457AD81B5552CA00919032 /* Matcher.swift */,
 				DC7F6B1F1AD82D3800CCBF6D /* Mock.swift */,
 				DC4D883D1E1CFCAE00FAE93F /* Pattern.swift */,
 				DC4D88371E1CECE100FAE93F /* Recorder.swift */,
-				DC7F6B1D1AD82B8C00CCBF6D /* Stub.swift */,
 				DC3CFE761ADE895E004728C2 /* Extensions */,
 				DC7F6AFB1AD8291800CCBF6D /* Supporting Files */,
 			);
@@ -220,11 +220,11 @@
 		DC7F6B071AD8291800CCBF6D /* DobbyTests */ = {
 			isa = PBXGroup;
 			children = (
+				DC7F6B261AD830B500CCBF6D /* BehaviorSpec.swift */,
 				DCE4080D1B6161000009E0B4 /* MatcherSpec.swift */,
 				DC7F6B241AD830A500CCBF6D /* MockSpec.swift */,
 				DC4D88431E1F9A5500FAE93F /* PatternSpec.swift */,
 				DC4D883A1E1CF8D700FAE93F /* RecorderSpec.swift */,
-				DC7F6B261AD830B500CCBF6D /* StubSpec.swift */,
 				DC7F6B081AD8291800CCBF6D /* Supporting Files */,
 			);
 			path = DobbyTests;
@@ -511,7 +511,7 @@
 				DC457AD91B5552CA00919032 /* Matcher.swift in Sources */,
 				DC3CFE781ADE895E004728C2 /* SwiftExtensions.swift in Sources */,
 				DC83356C1B56661900569709 /* Disposable.swift in Sources */,
-				DC7F6B1E1AD82B8C00CCBF6D /* Stub.swift in Sources */,
+				DC7F6B1E1AD82B8C00CCBF6D /* Behavior.swift in Sources */,
 				DC7F6B201AD82D3800CCBF6D /* Mock.swift in Sources */,
 				DC4D88391E1CECE100FAE93F /* Recorder.swift in Sources */,
 				DC4D883F1E1CFCAE00FAE93F /* Pattern.swift in Sources */,
@@ -526,7 +526,7 @@
 				DC7F6B251AD830A500CCBF6D /* MockSpec.swift in Sources */,
 				DC4D883C1E1CF8D700FAE93F /* RecorderSpec.swift in Sources */,
 				DC4D88451E1F9A5500FAE93F /* PatternSpec.swift in Sources */,
-				DC7F6B271AD830B500CCBF6D /* StubSpec.swift in Sources */,
+				DC7F6B271AD830B500CCBF6D /* BehaviorSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -537,7 +537,7 @@
 				DC457ADA1B5552CA00919032 /* Matcher.swift in Sources */,
 				DC3CFE791ADE895E004728C2 /* SwiftExtensions.swift in Sources */,
 				DC83356D1B56661900569709 /* Disposable.swift in Sources */,
-				DC8452401ADBF73C006AC5D4 /* Stub.swift in Sources */,
+				DC8452401ADBF73C006AC5D4 /* Behavior.swift in Sources */,
 				DC84523F1ADBF73C006AC5D4 /* Mock.swift in Sources */,
 				DC4D88381E1CECE100FAE93F /* Recorder.swift in Sources */,
 				DC4D883E1E1CFCAE00FAE93F /* Pattern.swift in Sources */,
@@ -552,7 +552,7 @@
 				DC8452421ADBF743006AC5D4 /* MockSpec.swift in Sources */,
 				DC4D883B1E1CF8D700FAE93F /* RecorderSpec.swift in Sources */,
 				DC4D88441E1F9A5500FAE93F /* PatternSpec.swift in Sources */,
-				DC8452431ADBF743006AC5D4 /* StubSpec.swift in Sources */,
+				DC8452431ADBF743006AC5D4 /* BehaviorSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Dobby.xcodeproj/project.pbxproj
+++ b/Dobby.xcodeproj/project.pbxproj
@@ -16,10 +16,10 @@
 		DC4D88391E1CECE100FAE93F /* Recorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D88371E1CECE100FAE93F /* Recorder.swift */; };
 		DC4D883B1E1CF8D700FAE93F /* RecorderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D883A1E1CF8D700FAE93F /* RecorderSpec.swift */; };
 		DC4D883C1E1CF8D700FAE93F /* RecorderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D883A1E1CF8D700FAE93F /* RecorderSpec.swift */; };
-		DC4D883E1E1CFCAE00FAE93F /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D883D1E1CFCAE00FAE93F /* Behavior.swift */; };
-		DC4D883F1E1CFCAE00FAE93F /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D883D1E1CFCAE00FAE93F /* Behavior.swift */; };
-		DC4D88441E1F9A5500FAE93F /* BehaviorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D88431E1F9A5500FAE93F /* BehaviorSpec.swift */; };
-		DC4D88451E1F9A5500FAE93F /* BehaviorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D88431E1F9A5500FAE93F /* BehaviorSpec.swift */; };
+		DC4D883E1E1CFCAE00FAE93F /* Pattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D883D1E1CFCAE00FAE93F /* Pattern.swift */; };
+		DC4D883F1E1CFCAE00FAE93F /* Pattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D883D1E1CFCAE00FAE93F /* Pattern.swift */; };
+		DC4D88441E1F9A5500FAE93F /* PatternSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D88431E1F9A5500FAE93F /* PatternSpec.swift */; };
+		DC4D88451E1F9A5500FAE93F /* PatternSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC4D88431E1F9A5500FAE93F /* PatternSpec.swift */; };
 		DC7F6AFE1AD8291800CCBF6D /* Dobby.h in Headers */ = {isa = PBXBuildFile; fileRef = DC7F6AFD1AD8291800CCBF6D /* Dobby.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DC7F6B041AD8291800CCBF6D /* Dobby.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC7F6AF81AD8291800CCBF6D /* Dobby.framework */; };
 		DC7F6B1E1AD82B8C00CCBF6D /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7F6B1D1AD82B8C00CCBF6D /* Stub.swift */; };
@@ -82,8 +82,8 @@
 		DC457AD81B5552CA00919032 /* Matcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Matcher.swift; sourceTree = "<group>"; };
 		DC4D88371E1CECE100FAE93F /* Recorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Recorder.swift; sourceTree = "<group>"; };
 		DC4D883A1E1CF8D700FAE93F /* RecorderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecorderSpec.swift; sourceTree = "<group>"; };
-		DC4D883D1E1CFCAE00FAE93F /* Behavior.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Behavior.swift; sourceTree = "<group>"; };
-		DC4D88431E1F9A5500FAE93F /* BehaviorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BehaviorSpec.swift; sourceTree = "<group>"; };
+		DC4D883D1E1CFCAE00FAE93F /* Pattern.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pattern.swift; sourceTree = "<group>"; };
+		DC4D88431E1F9A5500FAE93F /* PatternSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PatternSpec.swift; sourceTree = "<group>"; };
 		DC7F6AF81AD8291800CCBF6D /* Dobby.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Dobby.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC7F6AFC1AD8291800CCBF6D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DC7F6AFD1AD8291800CCBF6D /* Dobby.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Dobby.h; sourceTree = "<group>"; };
@@ -196,11 +196,11 @@
 		DC7F6AFA1AD8291800CCBF6D /* Dobby */ = {
 			isa = PBXGroup;
 			children = (
-				DC4D883D1E1CFCAE00FAE93F /* Behavior.swift */,
 				DC83356B1B56661900569709 /* Disposable.swift */,
 				DC7F6AFD1AD8291800CCBF6D /* Dobby.h */,
 				DC457AD81B5552CA00919032 /* Matcher.swift */,
 				DC7F6B1F1AD82D3800CCBF6D /* Mock.swift */,
+				DC4D883D1E1CFCAE00FAE93F /* Pattern.swift */,
 				DC4D88371E1CECE100FAE93F /* Recorder.swift */,
 				DC7F6B1D1AD82B8C00CCBF6D /* Stub.swift */,
 				DC3CFE761ADE895E004728C2 /* Extensions */,
@@ -220,9 +220,9 @@
 		DC7F6B071AD8291800CCBF6D /* DobbyTests */ = {
 			isa = PBXGroup;
 			children = (
-				DC4D88431E1F9A5500FAE93F /* BehaviorSpec.swift */,
 				DCE4080D1B6161000009E0B4 /* MatcherSpec.swift */,
 				DC7F6B241AD830A500CCBF6D /* MockSpec.swift */,
+				DC4D88431E1F9A5500FAE93F /* PatternSpec.swift */,
 				DC4D883A1E1CF8D700FAE93F /* RecorderSpec.swift */,
 				DC7F6B261AD830B500CCBF6D /* StubSpec.swift */,
 				DC7F6B081AD8291800CCBF6D /* Supporting Files */,
@@ -514,7 +514,7 @@
 				DC7F6B1E1AD82B8C00CCBF6D /* Stub.swift in Sources */,
 				DC7F6B201AD82D3800CCBF6D /* Mock.swift in Sources */,
 				DC4D88391E1CECE100FAE93F /* Recorder.swift in Sources */,
-				DC4D883F1E1CFCAE00FAE93F /* Behavior.swift in Sources */,
+				DC4D883F1E1CFCAE00FAE93F /* Pattern.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -525,7 +525,7 @@
 				DCE4080E1B6161000009E0B4 /* MatcherSpec.swift in Sources */,
 				DC7F6B251AD830A500CCBF6D /* MockSpec.swift in Sources */,
 				DC4D883C1E1CF8D700FAE93F /* RecorderSpec.swift in Sources */,
-				DC4D88451E1F9A5500FAE93F /* BehaviorSpec.swift in Sources */,
+				DC4D88451E1F9A5500FAE93F /* PatternSpec.swift in Sources */,
 				DC7F6B271AD830B500CCBF6D /* StubSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -540,7 +540,7 @@
 				DC8452401ADBF73C006AC5D4 /* Stub.swift in Sources */,
 				DC84523F1ADBF73C006AC5D4 /* Mock.swift in Sources */,
 				DC4D88381E1CECE100FAE93F /* Recorder.swift in Sources */,
-				DC4D883E1E1CFCAE00FAE93F /* Behavior.swift in Sources */,
+				DC4D883E1E1CFCAE00FAE93F /* Pattern.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -551,7 +551,7 @@
 				DCE4080F1B6161000009E0B4 /* MatcherSpec.swift in Sources */,
 				DC8452421ADBF743006AC5D4 /* MockSpec.swift in Sources */,
 				DC4D883B1E1CF8D700FAE93F /* RecorderSpec.swift in Sources */,
-				DC4D88441E1F9A5500FAE93F /* BehaviorSpec.swift in Sources */,
+				DC4D88441E1F9A5500FAE93F /* PatternSpec.swift in Sources */,
 				DC8452431ADBF743006AC5D4 /* StubSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Dobby/Behavior.swift
+++ b/Dobby/Behavior.swift
@@ -28,6 +28,9 @@ public final class Behavior<Value, ReturnValue> {
     /// The reactions of this behavior.
     private var reactions: [(identifier: UInt, reaction: Reaction<Value, ReturnValue>)] = []
 
+    /// The recorder of this behavior.
+    fileprivate let recorder: Recorder<Value> = Recorder()
+
     /// Creates a new behavior.
     public init() {
         
@@ -78,6 +81,8 @@ public final class Behavior<Value, ReturnValue> {
     ///     interaction is unexpected.
     @discardableResult
     public func invoke(_ value: Value) throws -> ReturnValue {
+        recorder.record(value)
+
         for (_, reaction) in reactions {
             if reaction.matcher.matches(value) {
                 return reaction.handler(value)
@@ -85,5 +90,15 @@ public final class Behavior<Value, ReturnValue> {
         }
 
         throw BehaviorError<Value, ReturnValue>.unexpectedInteraction(value)
+    }
+}
+
+extension Behavior: ValueRecording {
+    public var interactions: AnyRandomAccessCollection<Interaction> {
+        return recorder.interactions
+    }
+
+    public func valueForInteraction(at index: Int) -> Value {
+        return recorder.valueForInteraction(at: index)
     }
 }

--- a/Dobby/Behavior.swift
+++ b/Dobby/Behavior.swift
@@ -1,0 +1,284 @@
+import XCTest
+
+/// A value type-erased expectation.
+fileprivate struct Expectation: CustomStringConvertible {
+    fileprivate let description: String
+
+    /// The matching closure of this expectation.
+    ///
+    /// Given the index of a recorded interaction, the closure is supposed to
+    /// check whether the corresponding value fulfills this expectation.
+    fileprivate let matches: (Int) -> Bool
+
+    /// The recorder that is expected (not) to record an interaction with a
+    /// corresponding matching value.
+    fileprivate let recorder: InteractionRecording
+
+    /// Whether this expectation is negative.
+    fileprivate let negative: Bool
+
+    /// The file in which this expectation was set up.
+    fileprivate let file: StaticString
+
+    /// The line at which this expectation was set up.
+    fileprivate let line: UInt
+
+    /// Creates a new value type-erased expectation with the given description,
+    /// matching closure, recorder, and negative flag.
+    fileprivate init(description: String, matches: @escaping (Int) -> Bool, recorder: InteractionRecording, negative: Bool, file: StaticString, line: UInt) {
+        self.description = description
+        self.matches = matches
+
+        self.recorder = recorder
+        self.negative = negative
+
+        self.file = file
+        self.line = line
+    }
+
+    /// Creates a new value type-erased expectation with the given matcher,
+    /// recorder, and negative flag using the matcher's textual representation
+    /// as description.
+    fileprivate init<Matcher: MatcherConvertible, Recorder: ValueRecording>(matcher: Matcher, recorder: Recorder, negative: Bool, file: StaticString, line: UInt) where Matcher.ValueType == Recorder.Value {
+        let actualMatcher = matcher.matcher()
+
+        // The matching closure captures the value type of the recorder.
+        let matches = { (index: Int) -> Bool in
+            let actualValue = recorder.valueForInteraction(at: index)
+            return actualMatcher.matches(actualValue)
+        }
+
+        self.init(description: actualMatcher.description, matches: matches, recorder: recorder, negative: negative, file: file, line: line)
+    }
+}
+
+/// An iterator over a given set of interaction recorders, producing their
+/// interactions in chronological order.
+fileprivate struct InteractionRecordingIterator: IteratorProtocol {
+    fileprivate struct Element: CustomStringConvertible {
+        fileprivate let recorder: InteractionRecording
+
+        fileprivate var index: Int
+
+        fileprivate var interaction: Interaction {
+            return recorder.interactions[AnyIndex(index)]
+        }
+
+        fileprivate var description: String {
+            return interaction.description
+        }
+
+        fileprivate var timestamp: Timestamp {
+            return interaction.timestamp
+        }
+
+        fileprivate var file: StaticString {
+            return interaction.file
+        }
+
+        fileprivate var line: UInt {
+            return interaction.line
+        }
+    }
+
+    private var elements: [Element]
+
+    private mutating func heapify(at index: Int) {
+        var parentIndex = index
+
+        while parentIndex < elements.count {
+            let leftChildIndex = 2 * parentIndex + 1
+            let rightChildIndex = 2 * parentIndex + 2
+
+            var smallestIndex = parentIndex
+
+            if leftChildIndex < elements.count && elements[leftChildIndex].timestamp < elements[smallestIndex].timestamp {
+                smallestIndex = leftChildIndex
+            }
+
+            if rightChildIndex < elements.count && elements[rightChildIndex].timestamp < elements[smallestIndex].timestamp {
+                smallestIndex = rightChildIndex
+            }
+
+            if smallestIndex == parentIndex {
+                break
+            }
+
+            let parent = elements[parentIndex]
+            elements[parentIndex] = elements[smallestIndex]
+            elements[smallestIndex] = parent
+            
+            parentIndex = smallestIndex
+        }
+    }
+
+    fileprivate init(recorders: Set<AnyInteractionRecording>) {
+        elements = recorders.filter({ recorder in
+            return !recorder.interactions.isEmpty
+        }).map({ recorder in
+            return Element(recorder: recorder, index: 0)
+        })
+
+        for index in stride(from: (elements.count / 2 - 1), through: 0, by: -1) {
+            heapify(at: index)
+        }
+    }
+
+    fileprivate mutating func next() -> Element? {
+        guard let element = elements.first else {
+            return nil
+        }
+
+        if element.index + 1 == element.recorder.interactions.count {
+            if elements.count == 1 {
+                elements.removeLast()
+            } else {
+                elements[0] = elements.removeLast()
+            }
+        } else {
+            elements[0].index += 1
+        }
+
+        heapify(at: 0)
+
+        return element
+    }
+}
+
+/// A thread-safe behavior that can verify set up expectations with multiple
+/// interaction recorders.
+public final class Behavior {
+    /// Whether this behavior is strict (or nice).
+    private let strict: Bool
+
+    /// Whether the order of expectations matters.
+    private let ordered: Bool
+
+    /// All set up expectations.
+    private var expectations: [Expectation] = []
+    private let expectationsQueue = DispatchQueue(label: "com.trivago.dobby.behavior-expectationsQueue", attributes: .concurrent)
+
+    /// Creates a new behavior with the given strict and ordered flags.
+    public init(strict: Bool = true, ordered: Bool = true) {
+        self.strict = strict
+        self.ordered = ordered
+    }
+
+    /// Creates a new behavior with the given nice and ordered flags.
+    public convenience init(nice: Bool, ordered: Bool = true) {
+        self.init(strict: nice == false, ordered: ordered)
+    }
+
+    /// Sets up the given matcher as expectation for the given recorder.
+    public func expect<Matcher: MatcherConvertible, Recorder: ValueRecording>(_ matcher: Matcher, in recorder: Recorder, file: StaticString = #file, line: UInt = #line) where Matcher.ValueType == Recorder.Value {
+        let expectation = Expectation(matcher: matcher, recorder: recorder, negative: false, file: file, line: line)
+
+        expectationsQueue.sync(flags: .barrier, execute: {
+            expectations.append(expectation)
+        })
+    }
+
+    /// Sets up the given matcher as negative expectation for the given
+    /// recorder, meaning any matching value will be rejected.
+    ///
+    /// - Note: Negative expectations are restricted to nice behaviors.
+    public func reject<Matcher: MatcherConvertible, Recorder: ValueRecording>(_ matcher: Matcher, in recorder: Recorder, file: StaticString = #file, line: UInt = #line) where Matcher.ValueType == Recorder.Value {
+        precondition(strict == false, "Only nice behaviors may have negative expectations.")
+
+        let expectation = Expectation(matcher: matcher, recorder: recorder, negative: true, file: file, line: line)
+
+        expectationsQueue.sync(flags: .barrier, execute: {
+            expectations.append(expectation)
+        })
+    }
+
+    /// Verifies that all set up expectations are fulfilled by continuously
+    /// checking at each poll interval until the timeout is reached.
+    public func verify(poll: TimeInterval = 0.01, timeout: TimeInterval = 0) {
+        verify(poll: poll, timeout: timeout, fail: XCTFail)
+    }
+
+    internal func verify(poll: TimeInterval, timeout: TimeInterval, fail: (String, StaticString, UInt) -> ()) {
+        var failures: [(String, StaticString, UInt)]
+
+        // Set the initial limit date to now.
+        var limitDate = Date()
+
+        // Set the timeout date using the specified timeout.
+        let timeoutDate = Date(timeInterval: timeout, since: limitDate)
+
+        // Repetitively attempt to verify that all set up expectations are
+        // fulfilled until the timeout is reached.
+        repeat {
+            // Discard any previous failures.
+            failures = []
+
+            // Attempt to verify that all set up expectations are fulfilled.
+            verify(fail: { message, file, line in
+                failures.append((message, file, line))
+            })
+
+            // Finish if verification was successful.
+            if failures.isEmpty {
+                return
+            }
+
+            // Add the poll time interval to the limit date.
+            limitDate = Date(timeInterval: poll, since: limitDate)
+
+            // Run the current loop until the limit date, at most until the
+            // timeout date. Nimble uses a more advanced technique based on
+            // dispatch sources, we should take a look.
+            let currentLoop: RunLoop = .current
+            currentLoop.run(until: min(limitDate, timeoutDate))
+        } while Date() < timeoutDate
+
+        for (message, file, line) in failures {
+            fail(message, file, line)
+        }
+    }
+
+    internal func verify(fail: (String, StaticString, UInt) -> ()) {
+        var expectations = expectationsQueue.sync(execute: {
+            return self.expectations
+        })
+
+        let recorders = Set(expectations.map({ expectation in
+            return AnyInteractionRecording(expectation.recorder)
+        }))
+
+        let iterator = InteractionRecordingIterator(recorders: recorders)
+
+        replay: for interaction in IteratorSequence(iterator) {
+            for (index, expectation) in expectations.enumerated() {
+                if expectation.recorder.objectIdentifier == interaction.recorder.objectIdentifier && expectation.matches(interaction.index) {
+                    if expectation.negative == false {
+                        expectations.remove(at: index)
+                    } else {
+                        fail("Interaction <\(interaction)> not allowed", interaction.file, interaction.line)
+                    }
+
+                    continue replay
+                } else if ordered {
+                    if strict {
+                        fail("Interaction <\(interaction)> does not match expectation <\(expectation)>", interaction.file, interaction.line)
+                    }
+
+                    if expectation.negative == false {
+                        continue replay
+                    }
+                }
+            }
+
+            if strict {
+                fail("Interaction <\(interaction)> not expected", interaction.file, interaction.line)
+            }
+        }
+
+        for expectation in expectations {
+            if expectation.negative == false {
+                fail("Expectation <\(expectation)> not fulfilled", expectation.file, expectation.line)
+            }
+        }
+    }
+}

--- a/Dobby/Behavior.swift
+++ b/Dobby/Behavior.swift
@@ -4,10 +4,10 @@ fileprivate struct Reaction<Value, ReturnValue> {
     fileprivate let matcher: Matcher<Value>
 
     /// The handler of this reaction.
-    fileprivate let handler: (Value) -> ReturnValue
+    fileprivate let handler: (Value) throws -> ReturnValue
 
     /// Initializes a new reaction with the given matcher and handler.
-    fileprivate init<Matcher: MatcherConvertible>(matcher: Matcher, handler: @escaping (Value) -> ReturnValue) where Matcher.ValueType == Value {
+    fileprivate init<Matcher: MatcherConvertible>(matcher: Matcher, handler: @escaping (Value) throws -> ReturnValue) where Matcher.ValueType == Value {
         self.matcher = matcher.matcher()
         self.handler = handler
     }
@@ -42,7 +42,7 @@ public final class Behavior<Value, ReturnValue> {
     ///
     /// Returns a disposable that, when disposed, removes this reaction.
     @discardableResult
-    public func on<Matcher: MatcherConvertible>(_ matcher: Matcher, invoke handler: @escaping (Value) -> ReturnValue) -> Disposable where Matcher.ValueType == Value {
+    public func on<Matcher: MatcherConvertible>(_ matcher: Matcher, invoke handler: @escaping (Value) throws -> ReturnValue) -> Disposable where Matcher.ValueType == Value {
         currentIdentifier += 1
 
         let identifier = currentIdentifier
@@ -85,7 +85,7 @@ public final class Behavior<Value, ReturnValue> {
 
         for (_, reaction) in reactions {
             if reaction.matcher.matches(value) {
-                return reaction.handler(value)
+                return try reaction.handler(value)
             }
         }
 

--- a/Dobby/Behavior.swift
+++ b/Dobby/Behavior.swift
@@ -13,29 +13,29 @@ fileprivate struct Reaction<Value, ReturnValue> {
     }
 }
 
-/// A stub error.
-public enum StubError<Value, ReturnValue>: Error {
+/// A behavior error.
+public enum BehaviorError<Value, ReturnValue>: Error {
     /// An interaction with the associated value was unexpected.
     case unexpectedInteraction(Value)
 }
 
-/// A stub that, when invoked, returns a value based on the set up reactions,
-/// or, if an interaction is unexpected, throws an error.
-public final class Stub<Value, ReturnValue> {
+/// A behavior that, when invoked, returns a value based on the set up
+/// reactions, or, if an interaction is unexpected, throws an error.
+public final class Behavior<Value, ReturnValue> {
     /// The current (next) identifier for reactions.
     private var currentIdentifier: UInt = 0
 
-    /// The reactions of this stub.
+    /// The reactions of this behavior.
     private var reactions: [(identifier: UInt, reaction: Reaction<Value, ReturnValue>)] = []
 
-    /// Creates a new stub.
+    /// Creates a new behavior.
     public init() {
         
     }
 
-    /// Modifies the reactions of this stub, forwarding invocations to the
-    /// given handler and returning its return value if the given matcher
-    /// does match an interaction.
+    /// Modifies the reactions of this behavior, forwarding invocations to the
+    /// given handler and returning its return value if the given matcher does
+    /// match an interaction.
     ///
     /// Returns a disposable that, when disposed, removes this reaction.
     @discardableResult
@@ -57,24 +57,24 @@ public final class Stub<Value, ReturnValue> {
         }
     }
 
-    /// Modifies the reactions of this stub, returning the given value upon
+    /// Modifies the reactions of this behavior, returning the given value upon
     /// invocation if the given matcher does match an interaction.
     ///
     /// Returns a disposable that, when disposed, removes this reaction.
     ///
-    /// - SeeAlso: `Stub.on<Matcher>(matcher: Matcher, invoke: (Value) -> ReturnValue) -> Disposable`
+    /// - SeeAlso: `Behavior.on<Matcher>(matcher: Matcher, invoke: (Value) -> ReturnValue) -> Disposable`
     @discardableResult
     public func on<Matcher: MatcherConvertible>(_ matcher: Matcher, return value: ReturnValue) -> Disposable where Matcher.ValueType == Value {
         return on(matcher) { _ in value }
     }
 
-    /// Invokes this stub, returning a value based on the set up reactions, or,
-    /// if the given interaction is unexpected, throwing an error.
+    /// Invokes this behavior, returning a value based on the set up reactions,
+    /// or, if the given interaction is unexpected, throwing an error.
     ///
     /// Reactions are matched in order, i.e., the handler associated with the
     /// first matcher that matches the given interaction is invoked.
     ///
-    /// - Throws: `StubError.unexpectedInteraction(Value)` if the given
+    /// - Throws: `BehaviorError.unexpectedInteraction(Value)` if the given
     ///     interaction is unexpected.
     @discardableResult
     public func invoke(_ value: Value) throws -> ReturnValue {
@@ -84,6 +84,6 @@ public final class Stub<Value, ReturnValue> {
             }
         }
 
-        throw StubError<Value, ReturnValue>.unexpectedInteraction(value)
+        throw BehaviorError<Value, ReturnValue>.unexpectedInteraction(value)
     }
 }

--- a/Dobby/Mock.swift
+++ b/Dobby/Mock.swift
@@ -79,7 +79,9 @@ public final class Mock<Interaction> {
                     fail("Interaction <\(interaction)> does not match expectation <\(expectation)>", file, line)
                 }
 
-                return
+                if expectation.negative == false {
+                    return
+                }
             }
         }
 

--- a/Dobby/Pattern.swift
+++ b/Dobby/Pattern.swift
@@ -145,10 +145,10 @@ fileprivate struct InteractionRecordingIterator: IteratorProtocol {
     }
 }
 
-/// A thread-safe behavior that can verify set up expectations with multiple
+/// A thread-safe pattern that can verify set up expectations with multiple
 /// interaction recorders.
-public final class Behavior {
-    /// Whether this behavior is strict (or nice).
+public final class Pattern {
+    /// Whether this pattern is strict (or nice).
     private let strict: Bool
 
     /// Whether the order of expectations matters.
@@ -156,15 +156,15 @@ public final class Behavior {
 
     /// All set up expectations.
     private var expectations: [Expectation] = []
-    private let expectationsQueue = DispatchQueue(label: "com.trivago.dobby.behavior-expectationsQueue", attributes: .concurrent)
+    private let expectationsQueue = DispatchQueue(label: "com.trivago.dobby.pattern-expectationsQueue", attributes: .concurrent)
 
-    /// Creates a new behavior with the given strict and ordered flags.
+    /// Creates a new pattern with the given strict and ordered flags.
     public init(strict: Bool = true, ordered: Bool = true) {
         self.strict = strict
         self.ordered = ordered
     }
 
-    /// Creates a new behavior with the given nice and ordered flags.
+    /// Creates a new pattern with the given nice and ordered flags.
     public convenience init(nice: Bool, ordered: Bool = true) {
         self.init(strict: nice == false, ordered: ordered)
     }
@@ -181,9 +181,9 @@ public final class Behavior {
     /// Sets up the given matcher as negative expectation for the given
     /// recorder, meaning any matching value will be rejected.
     ///
-    /// - Note: Negative expectations are restricted to nice behaviors.
+    /// - Note: Negative expectations are restricted to nice patterns.
     public func reject<Matcher: MatcherConvertible, Recorder: ValueRecording>(_ matcher: Matcher, in recorder: Recorder, file: StaticString = #file, line: UInt = #line) where Matcher.ValueType == Recorder.Value {
-        precondition(strict == false, "Only nice behaviors may have negative expectations.")
+        precondition(strict == false, "Only nice patterns may have negative expectations.")
 
         let expectation = Expectation(matcher: matcher, recorder: recorder, negative: true, file: file, line: line)
 

--- a/Dobby/Recorder.swift
+++ b/Dobby/Recorder.swift
@@ -1,8 +1,9 @@
 /// A timestamp in a logical clock.
 public typealias Timestamp = UInt64
 
-private var timestamp: Timestamp = 0
-private let timestampQueue = DispatchQueue(label: "com.trivago.dobby-timestampQueue", attributes: .concurrent)
+/// A thread-safe global logical clock.
+fileprivate var timestamp: Timestamp = 0
+fileprivate let timestampQueue = DispatchQueue(label: "com.trivago.dobby-timestampQueue", attributes: .concurrent)
 
 /// Returns the current timestamp of the global clock.
 public var currentTimestamp: Timestamp {
@@ -19,30 +20,24 @@ public func nextTimestamp() -> Timestamp {
     })
 }
 
-/// A type that provides chronological access to recorded timestamps.
-public protocol TimestampRecording: class {
-    /// Returns the recorded timestamps in chronological order.
-    var timestamps: [Timestamp] { get }
-}
+/// A recorded interaction.
+public struct Interaction: CustomStringConvertible {
+    public let description: String
 
-/// An interaction, consisting of a timestamp and a value.
-public struct Interaction<Value> {
-    /// The time when the interaction occurred.
+    /// The time when this interaction was recorded.
     public let timestamp: Timestamp
 
-    /// The value of the interaction.
-    public let value: Value
-
-    /// The file in which the interaction occurred.
+    /// The file in which this interaction was recorded.
     public let file: StaticString
 
-    /// The line at which the interaction occurred.
+    /// The line at which this interaction was recorded.
     public let line: UInt
 
-    /// Creates a new interaction with the given value at the specified time.
-    public init(value: Value, timestamp: Timestamp, file: StaticString, line: UInt) {
+    /// Creates a new interaction with the given textual representation at the
+    /// specified time.
+    public init(description: String, timestamp: Timestamp, file: StaticString, line: UInt) {
+        self.description = description
         self.timestamp = timestamp
-        self.value = value
 
         self.file = file
         self.line = line
@@ -50,44 +45,123 @@ public struct Interaction<Value> {
 }
 
 /// A type that provides chronological access to recorded interactions.
-public protocol InteractionRecording: TimestampRecording {
-    /// The value type of recorded interactions.
+public protocol InteractionRecording: class {
+    /// Returns the unique identifier for this object.
+    var objectIdentifier: ObjectIdentifier { get }
+
+    /// Returns a random access collection that provides access to the recorded
+    /// interactions in chronological order.
+    var interactions: AnyRandomAccessCollection<Interaction> { get }
+}
+
+extension InteractionRecording {
+    public var objectIdentifier: ObjectIdentifier {
+        return ObjectIdentifier(self)
+    }
+}
+
+/// A type-erased, hashable interaction recorder. The hash value and equality
+/// operator are implemented using object identifiers.
+internal final class AnyInteractionRecording: InteractionRecording, Hashable {
+    /// The wrapped interaction recorder.
+    private let base: InteractionRecording
+
+    internal var objectIdentifier: ObjectIdentifier {
+        return base.objectIdentifier
+    }
+
+    internal var interactions: AnyRandomAccessCollection<Interaction> {
+        return base.interactions
+    }
+
+    internal var hashValue: Int {
+        return objectIdentifier.hashValue
+    }
+
+    /// Creates a type-erased, hashable interaction recorder that wraps the
+    /// given instance.
+    internal init(_ base: InteractionRecording) {
+        self.base = base
+    }
+}
+
+internal func == (lhs: AnyInteractionRecording, rhs: AnyInteractionRecording) -> Bool {
+    return lhs.objectIdentifier == rhs.objectIdentifier
+}
+
+/// A type that provides chronological access to recorded interactions and
+/// corresponding values.
+public protocol ValueRecording: InteractionRecording {
+    /// The type of recorded values.
     associatedtype Value
 
-    /// Returns the recorded interactions in chronological order.
-    var interactions: [Interaction<Value>] { get }
+    /// Returns the value corresponding to the interaction at the given index.
+    func valueForInteraction(at index: Int) -> Value
 }
 
-public extension InteractionRecording {
-    public var timestamps: [Timestamp] {
-        return interactions.map({ interaction in
-            return interaction.timestamp
-        })
+/// A recorded entry.
+fileprivate struct Entry<Value> {
+    /// The recorded interaction.
+    fileprivate let interaction: Interaction
+
+    /// The recorded value.
+    fileprivate let value: Value
+
+    /// Creates a new entry with the given interaction and value.
+    fileprivate init(interaction: Interaction, value: Value) {
+        self.interaction = interaction
+        self.value = value
+    }
+
+    /// Creates a new entry using the value's textual representation as
+    /// description for the interaction.
+    fileprivate init(value: Value, timestamp: Timestamp, file: StaticString, line: UInt) {
+        let interaction = Interaction(description: String(describing: value), timestamp: timestamp, file: file, line: line)
+
+        self.init(interaction: interaction, value: value)
     }
 }
 
-/// A recorder for interactions of the specified value type.
-public final class Recorder<Value>: InteractionRecording {
-    private var _interactions: [Interaction<Value>] = []
-    private let _interactionsQueue = DispatchQueue(label: "com.trivago.dobby.recorder-interactionsQueue", attributes: .concurrent)
-
-    public var interactions: [Interaction<Value>] {
-        return _interactionsQueue.sync(execute: {
-            return _interactions
-        })
-    }
+/// A thread-safe recorder for interactions of the specified value type.
+public final class Recorder<Value> {
+    fileprivate var entries: [Entry<Value>] = []
+    fileprivate let entriesQueue = DispatchQueue(label: "com.trivago.dobby.recorder-entriesQueue", attributes: .concurrent)
 
     /// Creates a new recorder.
     public init() {
 
     }
 
-    /// Records an interaction with the given value at the current timestamp of
-    /// the global clock.
+    /// Records an interaction with the given value.
     public func record(_ value: Value, file: StaticString = #file, line: UInt = #line) {
-        _interactionsQueue.sync(flags: .barrier, execute: {
-            let interaction = Interaction(value: value, timestamp: nextTimestamp(), file: file, line: line)
-            _interactions.append(interaction)
+        entriesQueue.sync(flags: .barrier, execute: {
+            // Get the next timestamp while executing on the entries queue to
+            // guarantee that entries are appended in chronological order.
+            let entry = Entry(value: value, timestamp: nextTimestamp(), file: file, line: line)
+
+            entries.append(entry)
         })
+    }
+}
+
+extension Recorder: ValueRecording {
+    public var interactions: AnyRandomAccessCollection<Interaction> {
+        let entries = entriesQueue.sync(execute: {
+            return self.entries
+        })
+
+        let interactions = entries.lazy.map({ entry in
+            return entry.interaction
+        })
+
+        return AnyRandomAccessCollection(interactions)
+    }
+
+    public func valueForInteraction(at index: Int) -> Value {
+        let entries = entriesQueue.sync(execute: {
+            return self.entries
+        })
+
+        return entries[index].value
     }
 }

--- a/Dobby/Recorder.swift
+++ b/Dobby/Recorder.swift
@@ -1,0 +1,63 @@
+/// A timestamp in a logical clock.
+public typealias Timestamp = UInt64
+
+/// The current timestamp of the global clock.
+internal var currentTimestamp: Timestamp = 0
+
+/// A type that provides chronological access to recorded timestamps.
+public protocol TimestampRecording: class {
+    /// Returns the recorded timestamps in chronological order.
+    var timestamps: [Timestamp] { get }
+}
+
+/// An interaction, consisting of a timestamp and a value.
+public struct Interaction<Value> {
+    /// The time when the interaction occurred.
+    public let timestamp: Timestamp
+
+    /// The value of the interaction.
+    public let value: Value
+
+    /// Creates a new interaction with the given value at the specified time.
+    public init(value: Value, at timestamp: Timestamp) {
+        self.timestamp = timestamp
+        self.value = value
+    }
+}
+
+/// A type that provides chronological access to recorded interactions.
+public protocol InteractionRecording: TimestampRecording {
+    /// The value type of recorded interactions.
+    associatedtype Value
+
+    /// Returns the recorded interactions in chronological order.
+    var interactions: [Interaction<Value>] { get }
+}
+
+public extension InteractionRecording {
+    public var timestamps: [Timestamp] {
+        return interactions.map({ interaction in
+            return interaction.timestamp
+        })
+    }
+}
+
+/// A recorder for interactions of the specified value type.
+public final class Recorder<Value>: InteractionRecording {
+    public private(set) var interactions: [Interaction<Value>] = []
+
+    /// Creates a new recorder.
+    public init() {
+
+    }
+
+    /// Records an interaction with the given value at the current timestamp of
+    /// the global clock.
+    public func record(_ value: Value) {
+        let interaction = Interaction(value: value, at: currentTimestamp)
+        interactions.append(interaction)
+
+        // Advance the global clock.
+        currentTimestamp += 1
+    }
+}

--- a/Dobby/Recorder.swift
+++ b/Dobby/Recorder.swift
@@ -18,10 +18,19 @@ public struct Interaction<Value> {
     /// The value of the interaction.
     public let value: Value
 
+    /// The file in which the interaction occurred.
+    public let file: StaticString
+
+    /// The line at which the interaction occurred.
+    public let line: UInt
+
     /// Creates a new interaction with the given value at the specified time.
-    public init(value: Value, at timestamp: Timestamp) {
+    public init(value: Value, timestamp: Timestamp, file: StaticString, line: UInt) {
         self.timestamp = timestamp
         self.value = value
+
+        self.file = file
+        self.line = line
     }
 }
 
@@ -53,8 +62,8 @@ public final class Recorder<Value>: InteractionRecording {
 
     /// Records an interaction with the given value at the current timestamp of
     /// the global clock.
-    public func record(_ value: Value) {
-        let interaction = Interaction(value: value, at: currentTimestamp)
+    public func record(_ value: Value, file: StaticString = #file, line: UInt = #line) {
+        let interaction = Interaction(value: value, timestamp: currentTimestamp, file: file, line: line)
         interactions.append(interaction)
 
         // Advance the global clock.

--- a/Dobby/Stub.swift
+++ b/Dobby/Stub.swift
@@ -1,89 +1,89 @@
-/// A matcher-based behavior with closure-based handling.
-fileprivate struct Behavior<Interaction, ReturnValue> {
-    /// The matcher of this behavior.
-    fileprivate let matcher: Matcher<Interaction>
+/// A matcher-based reaction with closure-based handling.
+fileprivate struct Reaction<Value, ReturnValue> {
+    /// The matcher of this reaction.
+    fileprivate let matcher: Matcher<Value>
 
-    /// The handler of this behavior.
-    fileprivate let handler: (Interaction) -> ReturnValue
+    /// The handler of this reaction.
+    fileprivate let handler: (Value) -> ReturnValue
 
-    /// Initializes a new behavior with the given matcher and handler.
-    fileprivate init<M: MatcherConvertible>(matcher: M, handler: @escaping (Interaction) -> ReturnValue) where M.ValueType == Interaction {
+    /// Initializes a new reaction with the given matcher and handler.
+    fileprivate init<Matcher: MatcherConvertible>(matcher: Matcher, handler: @escaping (Value) -> ReturnValue) where Matcher.ValueType == Value {
         self.matcher = matcher.matcher()
         self.handler = handler
     }
 }
 
 /// A stub error.
-public enum StubError<Interaction, ReturnValue>: Error {
-    /// The associated interaction was unexpected.
-    case unexpectedInteraction(Interaction)
+public enum StubError<Value, ReturnValue>: Error {
+    /// An interaction with the associated value was unexpected.
+    case unexpectedInteraction(Value)
 }
 
-/// A stub that, when invoked, returns a value based on the set up behavior, or,
-/// if an interaction is unexpected, throws an error.
-public final class Stub<Interaction, ReturnValue> {
-    /// The current (next) identifier for behaviors.
+/// A stub that, when invoked, returns a value based on the set up reactions,
+/// or, if an interaction is unexpected, throws an error.
+public final class Stub<Value, ReturnValue> {
+    /// The current (next) identifier for reactions.
     private var currentIdentifier: UInt = 0
 
-    /// The behaviors of this stub.
-    private var behaviors: [(identifier: UInt, behavior: Behavior<Interaction, ReturnValue>)] = []
+    /// The reactions of this stub.
+    private var reactions: [(identifier: UInt, reaction: Reaction<Value, ReturnValue>)] = []
 
-    /// Initializes a new stub.
+    /// Creates a new stub.
     public init() {
         
     }
 
-    /// Modifies the behavior of this stub, forwarding invocations to the given
-    /// function and returning its return value if the given matcher does match
-    /// an interaction.
+    /// Modifies the reactions of this stub, forwarding invocations to the
+    /// given handler and returning its return value if the given matcher
+    /// does match an interaction.
     ///
-    /// Returns a disposable that, when disposed, removes this behavior.
+    /// Returns a disposable that, when disposed, removes this reaction.
     @discardableResult
-    public func on<M: MatcherConvertible>(_ matcher: M, invoke handler: @escaping (Interaction) -> ReturnValue) -> Disposable where M.ValueType == Interaction {
+    public func on<Matcher: MatcherConvertible>(_ matcher: Matcher, invoke handler: @escaping (Value) -> ReturnValue) -> Disposable where Matcher.ValueType == Value {
         currentIdentifier += 1
 
         let identifier = currentIdentifier
-        let behavior = Behavior(matcher: matcher, handler: handler)
-        behaviors.append((identifier: identifier, behavior: behavior))
+        let reaction = Reaction(matcher: matcher, handler: handler)
+        reactions.append((identifier: identifier, reaction: reaction))
 
         return Disposable { [weak self] in
-            let index = self?.behaviors.index { otherIdentifier, _ in
+            let index = self?.reactions.index { otherIdentifier, _ in
                 return otherIdentifier == identifier
             }
 
             if let index = index {
-                self?.behaviors.remove(at: index)
+                self?.reactions.remove(at: index)
             }
         }
     }
 
-    /// Modifies the behavior of this stub, returning the given value upon
+    /// Modifies the reactions of this stub, returning the given value upon
     /// invocation if the given matcher does match an interaction.
     ///
-    /// Returns a disposable that, when disposed, removes this behavior.
+    /// Returns a disposable that, when disposed, removes this reaction.
     ///
-    /// - SeeAlso: `Stub.on<M>(matcher: M, invoke: Interaction -> ReturnValue) -> Disposable`
+    /// - SeeAlso: `Stub.on<Matcher>(matcher: Matcher, invoke: (Value) -> ReturnValue) -> Disposable`
     @discardableResult
-    public func on<M: MatcherConvertible>(_ matcher: M, return value: ReturnValue) -> Disposable where M.ValueType == Interaction {
+    public func on<Matcher: MatcherConvertible>(_ matcher: Matcher, return value: ReturnValue) -> Disposable where Matcher.ValueType == Value {
         return on(matcher) { _ in value }
     }
 
-    /// Invokes this stub, returning a value based on the set up behavior, or,
+    /// Invokes this stub, returning a value based on the set up reactions, or,
     /// if the given interaction is unexpected, throwing an error.
     ///
-    /// Behavior is matched in order, i.e., the function associated with the
+    /// Reactions are matched in order, i.e., the handler associated with the
     /// first matcher that matches the given interaction is invoked.
     ///
-    /// - Throws: `StubError.unexpectedInteraction(Interaction)` if the given
+    /// - Throws: `StubError.unexpectedInteraction(Value)` if the given
     ///     interaction is unexpected.
     @discardableResult
-    public func invoke(_ interaction: Interaction) throws -> ReturnValue {
-        for (_, behavior) in behaviors {
-            if behavior.matcher.matches(interaction) {
-                return behavior.handler(interaction)
+    public func invoke(_ value: Value) throws -> ReturnValue {
+        for (_, reaction) in reactions {
+            if reaction.matcher.matches(value) {
+                return reaction.handler(value)
             }
         }
 
-        throw StubError<Interaction, ReturnValue>.unexpectedInteraction(interaction)
+        throw StubError<Value, ReturnValue>.unexpectedInteraction(value)
     }
 }

--- a/DobbyTests/BehaviorSpec.swift
+++ b/DobbyTests/BehaviorSpec.swift
@@ -1,0 +1,254 @@
+import Quick
+import Nimble
+
+@testable import Dobby
+
+class BehaviorSpec: QuickSpec {
+    override func spec() {
+        var behavior: Behavior!
+
+        var recorder1: Recorder<Int>!
+        var recorder2: Recorder<Int>!
+
+        beforeEach {
+            recorder1 = Recorder()
+            recorder2 = Recorder()
+        }
+
+        describe("Verification") {
+            context("when the behavior is strict and the order of expectations does matter") {
+                beforeEach {
+                    behavior = Behavior(strict: true, ordered: true)
+                }
+
+                it("succeeds if all set up expectations are fulfilled") {
+                    recorder1.record(1)
+                    recorder2.record(2)
+
+                    behavior.expect(1, in: recorder1)
+                    behavior.expect(2, in: recorder2)
+                    behavior.verify()
+                }
+
+                it("fails if an interaction does not match the current expectation") {
+                    recorder1.record(1)
+                    recorder2.record(2)
+
+                    behavior.expect(1, in: recorder1)
+                    behavior.expect(3, in: recorder2)
+
+                    var failureMessages: [String] = []
+
+                    behavior.verify(fail: { message, _, _ in
+                        failureMessages.append(message)
+                    })
+
+                    expect(failureMessages).to(equal([
+                        "Interaction <2> does not match expectation <3>",
+                        "Expectation <3> not fulfilled"
+                    ]))
+                }
+
+                it("fails if an interaction is not expected") {
+                    recorder1.record(1)
+                    recorder1.record(2)
+
+                    behavior.expect(1, in: recorder1)
+
+                    var failureMessages: [String] = []
+
+                    behavior.verify(fail: { message, _, _ in
+                        failureMessages.append(message)
+                    })
+
+                    expect(failureMessages).to(equal([
+                        "Interaction <2> not expected"
+                    ]))
+                }
+
+                it("fails if any expectation is not fulfilled") {
+                    recorder1.record(1)
+
+                    behavior.expect(1, in: recorder1)
+                    behavior.expect(2, in: recorder2)
+
+                    var failureMessages: [String] = []
+
+                    behavior.verify(fail: { message, _, _ in
+                        failureMessages.append(message)
+                    })
+
+                    expect(failureMessages).to(equal([
+                        "Expectation <2> not fulfilled"
+                    ]))
+                }
+            }
+
+            context("when the behavior is strict and the order of expectations does not matter") {
+                beforeEach {
+                    behavior = Behavior(strict: true, ordered: false)
+                }
+
+                it("succeeds if all set up expectations are fulfilled") {
+                    recorder2.record(2)
+                    recorder1.record(1)
+
+                    behavior.expect(1, in: recorder1)
+                    behavior.expect(2, in: recorder2)
+                    behavior.verify()
+                }
+
+                it("fails if an interaction is not expected") {
+                    recorder1.record(2)
+                    recorder1.record(1)
+
+                    behavior.expect(1, in: recorder1)
+
+                    var failureMessages: [String] = []
+
+                    behavior.verify(fail: { message, _, _ in
+                        failureMessages.append(message)
+                    })
+
+                    expect(failureMessages).to(equal([
+                        "Interaction <2> not expected"
+                    ]))
+                }
+
+                it("fails if any expectation is not fulfilled") {
+                    recorder1.record(1)
+
+                    behavior.expect(2, in: recorder2)
+                    behavior.expect(1, in: recorder1)
+
+                    var failureMessages: [String] = []
+
+                    behavior.verify(fail: { message, _, _ in
+                        failureMessages.append(message)
+                    })
+
+                    expect(failureMessages).to(equal([
+                        "Expectation <2> not fulfilled"
+                    ]))
+                }
+            }
+
+            context("when the behavior is nice and the order of expectations does matter") {
+                beforeEach {
+                    behavior = Behavior(nice: true, ordered: true)
+                }
+
+                it("succeeds if all set up expectations are fulfilled") {
+                    recorder1.record(1)
+                    recorder2.record(2)
+                    recorder1.record(3)
+                    recorder2.record(4)
+
+                    behavior.expect(1, in: recorder1)
+                    behavior.expect(2, in: recorder2)
+                    behavior.verify()
+                }
+
+                it("fails if expectations are not fulfilled in order") {
+                    recorder1.record(3)
+                    recorder1.record(2)
+                    recorder1.record(1)
+
+                    behavior.expect(1, in: recorder1)
+                    behavior.expect(2, in: recorder1)
+
+                    var failureMessages: [String] = []
+
+                    behavior.verify(fail: { message, _, _ in
+                        failureMessages.append(message)
+                    })
+
+                    expect(failureMessages).to(equal([
+                        "Expectation <2> not fulfilled"
+                    ]))
+                }
+
+                it("fails if any expectation is not fulfilled") {
+                    recorder1.record(1)
+
+                    behavior.expect(1, in: recorder1)
+                    behavior.expect(2, in: recorder2)
+
+                    var failureMessages: [String] = []
+
+                    behavior.verify(fail: { message, _, _ in
+                        failureMessages.append(message)
+                    })
+
+                    expect(failureMessages).to(equal([
+                        "Expectation <2> not fulfilled"
+                    ]))
+                }
+            }
+
+            context("when the behavior is nice and the order of expectations does not matter") {
+                beforeEach {
+                    behavior = Behavior(nice: true, ordered: false)
+                }
+
+                it("succeeds if all set up expectations are fulfilled") {
+                    recorder2.record(4)
+                    recorder1.record(3)
+                    recorder2.record(2)
+                    recorder1.record(1)
+
+                    behavior.expect(1, in: recorder1)
+                    behavior.expect(2, in: recorder2)
+                    behavior.verify()
+                }
+
+                it("fails if any expectation is not fulfilled") {
+                    recorder1.record(1)
+
+                    behavior.expect(2, in: recorder2)
+                    behavior.expect(1, in: recorder1)
+
+                    var failureMessages: [String] = []
+
+                    behavior.verify(fail: { message, _, _ in
+                        failureMessages.append(message)
+                    })
+
+                    expect(failureMessages).to(equal([
+                        "Expectation <2> not fulfilled"
+                    ]))
+                }
+            }
+        }
+
+        describe("Verification with a timeout") {
+            beforeEach {
+                behavior = Behavior()
+            }
+
+            it("succeeds if all expectations are fulfilled before the timeout is reached") {
+                let mainQueue: DispatchQueue = .main
+                mainQueue.asyncAfter(deadline: .now() + 0.25) {
+                    recorder1.record(1)
+                }
+
+                behavior.expect(1, in: recorder1)
+                behavior.verify(timeout: 0.5)
+            }
+
+            it("fails if any expectation is not fulfilled before the timeout is reached") {
+                behavior.expect(1, in: recorder1)
+
+                var failureMessages: [String] = []
+
+                behavior.verify(fail: { message, _, _ in
+                    failureMessages.append(message)
+                })
+
+                expect(failureMessages).to(equal([
+                    "Expectation <1> not fulfilled"
+                ]))
+            }
+        }
+    }
+}

--- a/DobbyTests/BehaviorSpec.swift
+++ b/DobbyTests/BehaviorSpec.swift
@@ -3,38 +3,38 @@ import Nimble
 
 import Dobby
 
-class StubSpec: QuickSpec {
+class BehaviorSpec: QuickSpec {
     override func spec() {
-        var stub: Stub<(Int, Int), Int>!
+        var behavior: Behavior<(Int, Int), Int>!
 
         beforeEach {
-            stub = Stub()
+            behavior = Behavior()
         }
 
         describe("Invocation") {
             it("returns the correct value") {
-                stub.on(matches((4, 3)), return: 9)
-                stub.on(matches((any(), any()))) { $0.0 + $0.1 }
-                expect(try! stub.invoke((4, 3))).to(equal(9))
-                expect(try! stub.invoke((4, 4))).to(equal(8))
+                behavior.on(matches((4, 3)), return: 9)
+                behavior.on(matches((any(), any()))) { $0.0 + $0.1 }
+                expect(try! behavior.invoke((4, 3))).to(equal(9))
+                expect(try! behavior.invoke((4, 4))).to(equal(8))
             }
 
             it("returns the correct value after disposal") {
-                let disposable1 = stub.on(matches((4, 3)), return: 9)
-                let disposable2 = stub.on(matches((any(), any()))) { $0.0 + $0.1 }
+                let disposable1 = behavior.on(matches((4, 3)), return: 9)
+                let disposable2 = behavior.on(matches((any(), any()))) { $0.0 + $0.1 }
 
                 disposable1.dispose()
 
                 expect(disposable1.disposed).to(beTrue())
                 expect(disposable2.disposed).to(beFalse())
 
-                expect(try! stub.invoke((4, 3))).to(equal(7))
+                expect(try! behavior.invoke((4, 3))).to(equal(7))
             }
 
             it("throws an exception if an interaction is unexpected") {
                 do {
-                    try stub.invoke((5, 6))
-                } catch StubError<(Int, Int), Int>.unexpectedInteraction(let interaction) {
+                    try behavior.invoke((5, 6))
+                } catch BehaviorError<(Int, Int), Int>.unexpectedInteraction(let interaction) {
                     expect(interaction.0).to(equal(5))
                     expect(interaction.1).to(equal(6))
                     return;

--- a/DobbyTests/PatternSpec.swift
+++ b/DobbyTests/PatternSpec.swift
@@ -1,11 +1,11 @@
 import Quick
 import Nimble
 
-@testable import Dobby
+@testable import Dobby; import class Dobby.Pattern
 
-class BehaviorSpec: QuickSpec {
+class PatternSpec: QuickSpec {
     override func spec() {
-        var behavior: Behavior!
+        var pattern: Pattern!
 
         var recorder1: Recorder<Int>!
         var recorder2: Recorder<Int>!
@@ -16,30 +16,30 @@ class BehaviorSpec: QuickSpec {
         }
 
         describe("Verification") {
-            context("when the behavior is strict and the order of expectations does matter") {
+            context("when the pattern is strict and the order of expectations does matter") {
                 beforeEach {
-                    behavior = Behavior(strict: true, ordered: true)
+                    pattern = Pattern(strict: true, ordered: true)
                 }
 
                 it("succeeds if all set up expectations are fulfilled") {
                     recorder1.record(1)
                     recorder2.record(2)
 
-                    behavior.expect(1, in: recorder1)
-                    behavior.expect(2, in: recorder2)
-                    behavior.verify()
+                    pattern.expect(1, in: recorder1)
+                    pattern.expect(2, in: recorder2)
+                    pattern.verify()
                 }
 
                 it("fails if an interaction does not match the current expectation") {
                     recorder1.record(1)
                     recorder2.record(2)
 
-                    behavior.expect(1, in: recorder1)
-                    behavior.expect(3, in: recorder2)
+                    pattern.expect(1, in: recorder1)
+                    pattern.expect(3, in: recorder2)
 
                     var failureMessages: [String] = []
 
-                    behavior.verify(fail: { message, _, _ in
+                    pattern.verify(fail: { message, _, _ in
                         failureMessages.append(message)
                     })
 
@@ -53,11 +53,11 @@ class BehaviorSpec: QuickSpec {
                     recorder1.record(1)
                     recorder1.record(2)
 
-                    behavior.expect(1, in: recorder1)
+                    pattern.expect(1, in: recorder1)
 
                     var failureMessages: [String] = []
 
-                    behavior.verify(fail: { message, _, _ in
+                    pattern.verify(fail: { message, _, _ in
                         failureMessages.append(message)
                     })
 
@@ -69,12 +69,12 @@ class BehaviorSpec: QuickSpec {
                 it("fails if any expectation is not fulfilled") {
                     recorder1.record(1)
 
-                    behavior.expect(1, in: recorder1)
-                    behavior.expect(2, in: recorder2)
+                    pattern.expect(1, in: recorder1)
+                    pattern.expect(2, in: recorder2)
 
                     var failureMessages: [String] = []
 
-                    behavior.verify(fail: { message, _, _ in
+                    pattern.verify(fail: { message, _, _ in
                         failureMessages.append(message)
                     })
 
@@ -84,29 +84,29 @@ class BehaviorSpec: QuickSpec {
                 }
             }
 
-            context("when the behavior is strict and the order of expectations does not matter") {
+            context("when the pattern is strict and the order of expectations does not matter") {
                 beforeEach {
-                    behavior = Behavior(strict: true, ordered: false)
+                    pattern = Pattern(strict: true, ordered: false)
                 }
 
                 it("succeeds if all set up expectations are fulfilled") {
                     recorder2.record(2)
                     recorder1.record(1)
 
-                    behavior.expect(1, in: recorder1)
-                    behavior.expect(2, in: recorder2)
-                    behavior.verify()
+                    pattern.expect(1, in: recorder1)
+                    pattern.expect(2, in: recorder2)
+                    pattern.verify()
                 }
 
                 it("fails if an interaction is not expected") {
                     recorder1.record(2)
                     recorder1.record(1)
 
-                    behavior.expect(1, in: recorder1)
+                    pattern.expect(1, in: recorder1)
 
                     var failureMessages: [String] = []
 
-                    behavior.verify(fail: { message, _, _ in
+                    pattern.verify(fail: { message, _, _ in
                         failureMessages.append(message)
                     })
 
@@ -118,12 +118,12 @@ class BehaviorSpec: QuickSpec {
                 it("fails if any expectation is not fulfilled") {
                     recorder1.record(1)
 
-                    behavior.expect(2, in: recorder2)
-                    behavior.expect(1, in: recorder1)
+                    pattern.expect(2, in: recorder2)
+                    pattern.expect(1, in: recorder1)
 
                     var failureMessages: [String] = []
 
-                    behavior.verify(fail: { message, _, _ in
+                    pattern.verify(fail: { message, _, _ in
                         failureMessages.append(message)
                     })
 
@@ -133,9 +133,9 @@ class BehaviorSpec: QuickSpec {
                 }
             }
 
-            context("when the behavior is nice and the order of expectations does matter") {
+            context("when the pattern is nice and the order of expectations does matter") {
                 beforeEach {
-                    behavior = Behavior(nice: true, ordered: true)
+                    pattern = Pattern(nice: true, ordered: true)
                 }
 
                 it("succeeds if all set up expectations are fulfilled") {
@@ -144,9 +144,9 @@ class BehaviorSpec: QuickSpec {
                     recorder1.record(3)
                     recorder2.record(4)
 
-                    behavior.expect(1, in: recorder1)
-                    behavior.expect(2, in: recorder2)
-                    behavior.verify()
+                    pattern.expect(1, in: recorder1)
+                    pattern.expect(2, in: recorder2)
+                    pattern.verify()
                 }
 
                 it("fails if expectations are not fulfilled in order") {
@@ -154,12 +154,12 @@ class BehaviorSpec: QuickSpec {
                     recorder1.record(2)
                     recorder1.record(1)
 
-                    behavior.expect(1, in: recorder1)
-                    behavior.expect(2, in: recorder1)
+                    pattern.expect(1, in: recorder1)
+                    pattern.expect(2, in: recorder1)
 
                     var failureMessages: [String] = []
 
-                    behavior.verify(fail: { message, _, _ in
+                    pattern.verify(fail: { message, _, _ in
                         failureMessages.append(message)
                     })
 
@@ -171,12 +171,12 @@ class BehaviorSpec: QuickSpec {
                 it("fails if any expectation is not fulfilled") {
                     recorder1.record(1)
 
-                    behavior.expect(1, in: recorder1)
-                    behavior.expect(2, in: recorder2)
+                    pattern.expect(1, in: recorder1)
+                    pattern.expect(2, in: recorder2)
 
                     var failureMessages: [String] = []
 
-                    behavior.verify(fail: { message, _, _ in
+                    pattern.verify(fail: { message, _, _ in
                         failureMessages.append(message)
                     })
 
@@ -186,9 +186,9 @@ class BehaviorSpec: QuickSpec {
                 }
             }
 
-            context("when the behavior is nice and the order of expectations does not matter") {
+            context("when the pattern is nice and the order of expectations does not matter") {
                 beforeEach {
-                    behavior = Behavior(nice: true, ordered: false)
+                    pattern = Pattern(nice: true, ordered: false)
                 }
 
                 it("succeeds if all set up expectations are fulfilled") {
@@ -197,20 +197,20 @@ class BehaviorSpec: QuickSpec {
                     recorder2.record(2)
                     recorder1.record(1)
 
-                    behavior.expect(1, in: recorder1)
-                    behavior.expect(2, in: recorder2)
-                    behavior.verify()
+                    pattern.expect(1, in: recorder1)
+                    pattern.expect(2, in: recorder2)
+                    pattern.verify()
                 }
 
                 it("fails if any expectation is not fulfilled") {
                     recorder1.record(1)
 
-                    behavior.expect(2, in: recorder2)
-                    behavior.expect(1, in: recorder1)
+                    pattern.expect(2, in: recorder2)
+                    pattern.expect(1, in: recorder1)
 
                     var failureMessages: [String] = []
 
-                    behavior.verify(fail: { message, _, _ in
+                    pattern.verify(fail: { message, _, _ in
                         failureMessages.append(message)
                     })
 
@@ -223,7 +223,7 @@ class BehaviorSpec: QuickSpec {
 
         describe("Verification with a timeout") {
             beforeEach {
-                behavior = Behavior()
+                pattern = Pattern()
             }
 
             it("succeeds if all expectations are fulfilled before the timeout is reached") {
@@ -232,16 +232,16 @@ class BehaviorSpec: QuickSpec {
                     recorder1.record(1)
                 }
 
-                behavior.expect(1, in: recorder1)
-                behavior.verify(timeout: 0.5)
+                pattern.expect(1, in: recorder1)
+                pattern.verify(timeout: 0.5)
             }
 
             it("fails if any expectation is not fulfilled before the timeout is reached") {
-                behavior.expect(1, in: recorder1)
+                pattern.expect(1, in: recorder1)
 
                 var failureMessages: [String] = []
 
-                behavior.verify(fail: { message, _, _ in
+                pattern.verify(fail: { message, _, _ in
                     failureMessages.append(message)
                 })
 

--- a/DobbyTests/RecorderSpec.swift
+++ b/DobbyTests/RecorderSpec.swift
@@ -1,0 +1,30 @@
+import Quick
+import Nimble
+
+@testable import Dobby
+
+class RecorderSpec: QuickSpec {
+    override func spec() {
+        var recorder: Recorder<Int>!
+
+        beforeEach {
+            recorder = Recorder()
+        }
+
+        describe("Recording") {
+            it("appends an interaction to the recorder") {
+                let currentTimestamp = Dobby.currentTimestamp
+
+                recorder.record(1)
+
+                // Verify that the interaction has been appended.
+                expect(recorder.interactions).to(haveCount(1))
+                expect(recorder.interactions[0].timestamp).to(equal(currentTimestamp))
+                expect(recorder.interactions[0].value).to(equal(1))
+
+                // Verify that the global clock is advanced.
+                expect(Dobby.currentTimestamp).to(equal(currentTimestamp + 1))
+            }
+        }
+    }
+}

--- a/DobbyTests/RecorderSpec.swift
+++ b/DobbyTests/RecorderSpec.swift
@@ -12,17 +12,19 @@ class RecorderSpec: QuickSpec {
         }
 
         describe("Recording") {
-            it("appends an interaction to the recorder") {
+            it("appends an interaction and its corresponding value to the recorder") {
                 let currentTimestamp = Dobby.currentTimestamp
 
                 recorder.record(1)
 
-                // Verify that the interaction has been appended.
+                // Verify that the interaction has been recorded.
                 expect(recorder.interactions).to(haveCount(1))
-                expect(recorder.interactions[0].timestamp).to(equal(currentTimestamp))
-                expect(recorder.interactions[0].value).to(equal(1))
+                expect(recorder.interactions[AnyIndex(0)].timestamp).to(equal(currentTimestamp + 1))
 
-                // Verify that the global clock is advanced.
+                // Verify that the corresponding value has been recorded.
+                expect(recorder.valueForInteraction(at: 0)).to(equal(1))
+
+                // Verify that the global clock has been advanced.
                 expect(Dobby.currentTimestamp).to(equal(currentTimestamp + 1))
             }
         }


### PR DESCRIPTION
This pull request introduces several new types for recording interactions and corresponding values as well was verifying interactions with multiple recorders.

First, recording of interactions and corresponding values has been split up into two protocols, `InteractionRecording` and `ValueRecording`. Using protocols allows developers to define their own recorders if necessary. Dobby ships with one default, thread-safe recorder. None of the aforementioned protocols needs to deal with verification, they just need to take care of recording.

Second, verification has been re-implemented using `Pattern`, which is thread-safe too. Unlike mocks, patterns can verify set up expectations with *multiple* interaction recorders. For example, if your test double has multiple methods, you can easily verify that they are invoked in order:

```swift
class Thing {
    let fstRecorder = Recorder<Int>()
    let sndRecorder = Recorder<String>()

    func fst(x: Int) {
        fstRecorder.record(x)
    }

    func snd(y: String) {
        sndRecorder.record(y)
    }
}

let thing = Thing()
thing.fst(1)
thing.snd("foobar")

let pattern = Pattern()
pattern.expect(1, in: thing.fstRecorder)
pattern.expect("foobar", in: thing.sndRecorder)
pattern.verify()
```

Besides verification across multiple recorders, this has several other benefits. Whether expectations are strict or nice and must be fulfilled in order or not is no longer a property of the entity that records interactions. Stubs can easily act as recorders, greatly simplifying the writing of test doubles.

Under the hood, this is implemented using a thread-safe global logical clock that enables ordering interactions across multiple recorders. On verification, interactions are replayed in chronological order using a binary heap-based k-way merge iterator. Matching is based on recorder object identity and the existing matchers.

Mocks are still part of the framework, but I'm considering to remove them before we release this. Stubs haven't been extended yet.

I've had this idea in mind for quite a while, but with type-safety being one of my highest priorities, it took a while to come up with a nice solution. I think this is the future of Dobby and would appreciate collaborators and interested developers to have a look and provide feedback, thanks.