### PR TITLE
Disable bitcode while using Swift 2.3

### DIFF
--- a/Dobby.xcodeproj/project.pbxproj
+++ b/Dobby.xcodeproj/project.pbxproj
@@ -587,6 +587,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphonesimulator*]" = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
@@ -605,6 +606,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphonesimulator*]" = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",


### PR DESCRIPTION
Dobby links against XCTest which in Swift 2.3 was not built with bitcode
support.

For the 0.6.x release, bitcode should be disabled at the target level
so that when the setting is passed in by carthage it will be ignored
and a build will be successful

Closes #34, thanks @mdarnall!